### PR TITLE
Drop python 3.9 support

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,27 +30,17 @@ jobs:
       with:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Build and test including remote checks (3.9) mypy
+        python-version: '3.10'
+    - name: Build and test including remote checks (3.10) mypy
       if:  (matrix.os == 'macos-12') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule' )
       shell: bash
       run: |
         ./.github/workflows/build-test mypy
-    - name: Build and test including remote checks (3.9) nomypy
+    - name: Build and test including remote checks (3.10) nomypy
       if:  (matrix.os != 'macos-12') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule')
-      shell: bash
-      run: |
-        ./.github/workflows/build-test nomypy
-    - name: Set up Python 3.10
-      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-    - name: Build and test (3.10)
-      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy
@@ -104,10 +94,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Download all wheels
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -44,6 +44,26 @@ jobs:
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy
+    - name: Set up Python 3.11
+      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Build and test (3.11)
+      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
+      shell: bash
+      run: |
+        ./.github/workflows/build-test nomypy
+    - name: Set up Python 3.12
+      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Build and test (3.12)
+      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
+      shell: bash
+      run: |
+        ./.github/workflows/build-test nomypy
     - uses: actions/upload-artifact@v4
       if: github.event_name == 'release' || contains(github.ref, 'refs/heads/wheel')
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Upgrade pip and install wheel
       run: pip install --upgrade pip wheel
     - name: Install pytket pysimplex

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ be simulated using pysimplex.
 
 ## Getting started
 
-`pytket-pysimplex` is available for Python 3.10, on Linux, MacOS
+`pytket-pysimplex` is available for Python 3.10, 3.11 and 3.12, on Linux, MacOS
 and Windows. To install, run:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ be simulated using pysimplex.
 
 ## Getting started
 
-`pytket-pysimplex` is available for Python 3.9 and 3.10, on Linux, MacOS
+`pytket-pysimplex` is available for Python 3.10, on Linux, MacOS
 and Windows. To install, run:
 
 ```shell

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+General:
+
+* Python 3.12 support added, 3.9 dropped.
+* pytket dependency updated to 1.24
+
 0.12.0 (January 2024)
 ---------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,8 @@ Unreleased
 General:
 
 * Python 3.12 support added, 3.9 dropped.
-* pytket dependency updated to 1.24
+* pytket dependency updated to 1.24.
+* pysimplex dependency updated to 1.5.
 
 0.12.0 (January 2024)
 ---------------------

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -7,7 +7,7 @@ for large sparse circuits.
 ``pytket-pysimplex`` is an extension to ``pytket`` that allows ``pytket``
 circuits to be simulated using ``pysimplex``.
 
-``pytket-pysimplex`` is available for Python 3.10, on Linux, MacOS
+``pytket-pysimplex`` is available for Python 3.10, 3.11 and 3.12, on Linux, MacOS
 and Windows. To install, run:
 
 ::

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -7,7 +7,7 @@ for large sparse circuits.
 ``pytket-pysimplex`` is an extension to ``pytket`` that allows ``pytket``
 circuits to be simulated using ``pysimplex``.
 
-``pytket-pysimplex`` is available for Python 3.9 and 3.10, on Linux, MacOS
+``pytket-pysimplex`` is available for Python 3.10, on Linux, MacOS
 and Windows. To install, run:
 
 ::

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 1.24", "pysimplex ~= 1.4"],
+    install_requires=["pytket ~= 1.24", "pysimplex ~= 1.5"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 1.23", "pysimplex ~= 1.4"],
+    install_requires=["pytket ~= 1.24", "pysimplex ~= 1.4"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     version=metadata["__extension_version__"],
     author="TKET development team",
     author_email="tket-support@cambridgequantum.com",
-    python_requires=">=3.9",
+    python_requires="==3.10",
     project_urls={
         "Documentation": "https://tket.quantinuum.com/extensions/pytket-pysimplex/index.html",
         "Source": "https://github.com/CQCL/pytket-pysimplex",
@@ -46,7 +46,6 @@ setup(
     install_requires=["pytket ~= 1.23", "pysimplex ~= 1.4"],
     classifiers=[
         "Environment :: Console",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: MacOS :: MacOS X",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     version=metadata["__extension_version__"],
     author="TKET development team",
     author_email="tket-support@cambridgequantum.com",
-    python_requires="==3.10",
+    python_requires="~=3.10",
     project_urls={
         "Documentation": "https://tket.quantinuum.com/extensions/pytket-pysimplex/index.html",
         "Source": "https://github.com/CQCL/pytket-pysimplex",

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ setup(
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
Drop python3.9 support as pytket will no longer support it.

Is there a reason why there is no 3.11 support currently? Happy to add 3.11 and 3.12 in if desired.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
